### PR TITLE
Proposal for supporting uint32 and uint16 arrays

### DIFF
--- a/source/web/index.js
+++ b/source/web/index.js
@@ -57,8 +57,12 @@ export class XAtlasAPI{
      */
     addMesh(indexes, vertices, normals=null, coords=null, meshObj=undefined, useNormals = false, useCoords = false, scale =1){
         if(!this.loaded || !this.atlasCreated) throw "Create atlas first";
-        let meshDesc = this.xatlas.createMesh(vertices.length/3, indexes.length, normals != null && useNormals, coords != null && useCoords);
-        this.xatlas.HEAPU16.set(indexes, meshDesc.indexOffset/2);
+        let meshDesc = this.xatlas.createMesh(vertices.length/3, indexes.length, indexes instanceof Uint32Array, normals != null && useNormals, coords != null && useCoords);
+        if (indexes instanceof Uint32Array) {
+            this.xatlas.HEAPU32.set(indexes, meshDesc.indexOffset/4);
+        } else {
+            this.xatlas.HEAPU16.set(indexes, meshDesc.indexOffset/2);
+        }
 
         let vs = new Float32Array([...vertices]);
         if(scale!==1) {

--- a/source/web/xatlas_web.cpp
+++ b/source/web/xatlas_web.cpp
@@ -27,7 +27,7 @@ void createAtlas() {
     xatlas::SetProgressCallback(atlas, ProgressCallback, nullptr);
 }
 
-MeshBufferInfo createMesh(uint32_t vertexCount, uint32_t indexCount, bool normals, bool uvs) {
+MeshBufferInfo createMesh(uint32_t vertexCount, uint32_t indexCount, bool uint32Indices, bool normals, bool uvs) {
     MeshBufferInfo meshBufferInfo;
     meshBufferInfo.meshId = nextMeshId++;
 
@@ -35,8 +35,13 @@ MeshBufferInfo createMesh(uint32_t vertexCount, uint32_t indexCount, bool normal
     meshDecl->vertexCount = vertexCount;
     meshDecl->indexCount = indexCount;
 
-    meshDecl->indexData = new uint16_t[indexCount];
-    meshDecl->indexFormat = xatlas::IndexFormat::UInt16;
+    if (uint32Indices) {
+        meshDecl->indexData = new uint32_t[indexCount];
+        meshDecl->indexFormat = xatlas::IndexFormat::UInt32;
+    } else {
+        meshDecl->indexData = new uint16_t[indexCount];
+        meshDecl->indexFormat = xatlas::IndexFormat::UInt16;
+    }
     meshBufferInfo.indexOffset = (uint32_t) meshDecl->indexData;
 
     meshDecl->vertexPositionData = new float[vertexCount * 3];


### PR DESCRIPTION
I still don't have emscripten set up so I can't test this but here's a proposal at how Uint16 and Uint32 indices can be supported to (probably) help address https://github.com/repalash/xatlas-three/issues/1. Alternatively the project could be modified to _only_ take Uint32 indices but this approach is backwards compatible, if that's important.